### PR TITLE
Setup ssh-agent on .bashrc

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -1,0 +1,2 @@
+#!/bin/bash
+eval `ssh-agent -s` > /dev/null

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,6 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o semver cmd/semver/main.go
 
 FROM alpine:3
 COPY --from=builder /build/semver /bin/
+COPY .bashrc /root/.bashrc
 RUN apk update && apk add --no-cache git bash openssh curl
 CMD ["./bash"]


### PR DESCRIPTION
- add .bashrc file to Dockerfile to ensure ssh-agent to starts when open bash